### PR TITLE
stream: fix firefox datachannel readiness counting

### DIFF
--- a/teleoprtc/stream.py
+++ b/teleoprtc/stream.py
@@ -145,11 +145,14 @@ class WebRTCBaseStream(abc.ABC):
 
   def _parse_incoming_streams(self, remote_sdp: str):
     desc = aiortc.sdp.SessionDescription.parse(remote_sdp)
-    sending_medias = [m for m in desc.media if m.direction in ["sendonly", "sendrecv"]]
+    # Datachannels may include a direction attribute (e.g. Firefox uses sendrecv),
+    # but they are tracked separately via messaging_channel and should not be
+    # counted as generic sending media.
+    sending_medias = [m for m in desc.media if m.kind in ["audio", "video"] and m.direction in ["sendonly", "sendrecv"]]
     incoming_media_count = len(sending_medias)
     if not self.should_add_data_channel:
       channel_medias = [m for m in desc.media if m.kind == "application"]
-      incoming_media_count += len(channel_medias)
+      incoming_media_count += int(len(channel_medias) > 0)
     self.expected_number_of_incoming_media = incoming_media_count
 
   def has_incoming_video_track(self, camera_type: str) -> bool:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -78,6 +78,35 @@ class TestOfferStream:
 
 @pytest.mark.asyncio
 class TestAnswerStream:
+  def test_parse_incoming_streams_datachannel_not_double_counted(self):
+    offer_sdp = """v=0
+o=- 3910274679 3910274679 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE 0 1
+a=msid-semantic:WMS *
+m=video 9 UDP/TLS/RTP/SAVPF 97
+c=IN IP4 0.0.0.0
+a=recvonly
+a=mid:0
+a=ice-ufrag:1234
+a=ice-pwd:1234
+a=fingerprint:sha-256 15:F3:F0:23:67:44:EE:2C:AA:8C:D9:50:95:26:42:7C:67:EA:1F:D2:92:C5:97:01:7B:2E:57:C9:A3:13:00:4A
+a=setup:actpass
+m=application 9 UDP/DTLS/SCTP webrtc-datachannel
+c=IN IP4 0.0.0.0
+a=sendrecv
+a=mid:1
+a=sctp-port:5000
+a=max-message-size:262144"""
+
+    builder = WebRTCAnswerBuilder(offer_sdp)
+    stream = builder.stream()
+    stream._parse_incoming_streams(offer_sdp)
+
+    # Expect exactly one incoming media item for messaging channel.
+    assert stream.expected_number_of_incoming_media == 1
+
   async def test_codec_preference(self):
     offer_sdp = """v=0
 o=- 3910274679 3910274679 IN IP4 0.0.0.0


### PR DESCRIPTION
## Summary
I used an AI assistant to help trace this, then verified and tested the fix manually.

Fixes a Firefox-specific readiness bug in `WebRTCBaseStream._parse_incoming_streams` that prevented messaging (e.g. joystick commands) from being set up.

## Root cause
`expected_number_of_incoming_media` was over-counted when SDP included a datachannel media section (`m=application`) with `a=sendrecv` (common in Firefox).

The parser counted that application media twice:
1. in the generic `sendonly/sendrecv` media count
2. again in the explicit datachannel (`m.kind == "application"`) count

That made `expected_number_of_incoming_media` larger than the actual runtime media/events, so readiness never completed.

## Fix
- Restrict generic sending-media counting to `audio` and `video` only.
- Count datachannel presence as one messaging channel (`int(len(channel_medias) > 0)`), avoiding double-counting.

## Behavior
- Before: joystick/datachannel flow could work in Chrome but stall in Firefox.
- After: readiness completes correctly and messaging works in both Chrome and Firefox.

## Tests
- Added regression test:
  - `test_parse_incoming_streams_datachannel_not_double_counted`
- Command run:
  - `PYTHONPATH=. pytest -q -o addopts='' tests/test_stream.py -k datachannel_not_double_counted`
  - `1 passed`
