### PR TITLE
replace video codec overwrite with codec validate

### DIFF
--- a/teleoprtc/stream.py
+++ b/teleoprtc/stream.py
@@ -263,32 +263,24 @@ class WebRTCAnswerStream(WebRTCBaseStream):
 
     return codecs
 
-  def _override_incoming_video_codecs(self, remote_sdp: str, codecs: List[str]) -> str:
-    desc = aiortc.sdp.SessionDescription.parse(remote_sdp)
-    codec_mimes = [f"video/{c}" for c in codecs]
-    for m in desc.media:
-      if m.kind != "video":
-        continue
+  def _validate_codecs(self):
+    desc = aiortc.sdp.SessionDescription.parse(self.session.sdp)
+    video_media = [m for m in desc.media if m.kind == "video"]
+    offer_codecs = set()
+    for m in video_media:
+      for c in m.rtp.codecs:
+        offer_codecs.add(c.mimeType)
 
-      preferred_codecs: List[aiortc.RTCRtpCodecParameters] = [c for c in m.rtp.codecs if c.mimeType in codec_mimes]
-      if len(preferred_codecs) == 0:
-        raise ValueError(f"None of {preferred_codecs} codecs is supported in remote SDP")
-
-      m.rtp.codecs = preferred_codecs
-      m.fmt = [c.payloadType for c in preferred_codecs]
-
-    return str(desc)
+    for codec in self._probe_video_codecs():
+      codec_mime = f"video/{codec.upper()}"
+      if codec_mime not in offer_codecs:
+        raise ValueError(f"Preferred codec {codec_mime} is not available in the offer")
 
   async def start(self) -> aiortc.RTCSessionDescription:
     assert self.peer_connection.remoteDescription is None, "Connection already established"
 
+    self._validate_codecs()
     self._add_consumer_transceivers()
-
-    # since we sent already encoded frames in some cases (e.g. livestream video tracks are in H264), we need to force aiortc to actually use it
-    # we do that by overriding supported codec information on incoming sdp
-    preferred_codecs = self._probe_video_codecs()
-    if len(preferred_codecs) > 0:
-      self.session.sdp = self._override_incoming_video_codecs(self.session.sdp, preferred_codecs)
 
     self._parse_incoming_streams(remote_sdp=self.session.sdp)
     await self.peer_connection.setRemoteDescription(self.session)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -78,47 +78,6 @@ class TestOfferStream:
 
 @pytest.mark.asyncio
 class TestAnswerStream:
-  async def test_codec_preference(self):
-    offer_sdp = """v=0
-o=- 3910274679 3910274679 IN IP4 0.0.0.0
-s=-
-t=0 0
-a=group:BUNDLE 0
-a=msid-semantic:WMS *
-m=video 1337 UDP/TLS/RTP/SAVPF 97 98 99 100 101 102
-c=IN IP4 0.0.0.0
-a=recvonly
-a=mid:0
-a=msid:34803878-98f8-4245-b45c-f773e5f926df 881dbc20-356a-499c-b4e8-695303bb901d
-a=rtcp:9 IN IP4 0.0.0.0
-a=rtcp-mux
-a=ssrc-group:FID 1303546896 3784011659
-a=ssrc:1303546896 cname:a59185ac-c115-48d3-b39b-db7d615a6966
-a=ssrc:3784011659 cname:a59185ac-c115-48d3-b39b-db7d615a6966
-a=rtpmap:97 VP8/90000
-a=rtcp-fb:97 nack
-a=rtcp-fb:97 nack pli
-a=rtcp-fb:97 goog-remb
-a=rtpmap:99 H264/90000
-a=rtcp-fb:99 nack
-a=rtcp-fb:99 nack pli
-a=rtcp-fb:99 goog-remb
-a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
-a=ice-ufrag:1234
-a=ice-pwd:1234
-a=fingerprint:sha-256 15:F3:F0:23:67:44:EE:2C:AA:8C:D9:50:95:26:42:7C:67:EA:1F:D2:92:C5:97:01:7B:2E:57:C9:A3:13:00:4A
-a=setup:actpass"""
-
-    builder = WebRTCAnswerBuilder(offer_sdp)
-    builder.add_video_stream("road", DummyH264VideoStreamTrack("road", 0.05))
-    stream = builder.stream()
-    answer = await stream.start()
-
-    sdp_desc = aiortc.sdp.SessionDescription.parse(answer.sdp)
-    video_desc = [m for m in sdp_desc.media if m.kind == "video"][0]
-    codecs = video_desc.rtp.codecs
-    assert codecs[0].mimeType == "video/H264"
-
   async def test_fail_if_preferred_codec_not_in_offer(self):
     offer_sdp = """v=0
 o=- 3910274679 3910274679 IN IP4 0.0.0.0

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-import aiortc
 from aiortc.mediastreams import AudioStreamTrack
 
 from teleoprtc.builder import WebRTCOfferBuilder, WebRTCAnswerBuilder


### PR DESCRIPTION
leaving this here because it may be needed if webrtc wants to do multi-video channels or multi-audio (2-way audio)

remove overwriting video codecs. Parsing the sdp offer with aiortc, then serializing it to a string and then reparsing it in setRemoteDescription causes "RTCP mux is not enabled" error. There is no clean way to fix this through aiortc and requires fixing via manual string manipulation to edit Offer codecs but also keep rtcp-mux params. This can cause issues down the line since it is more to maintain. I opted instead for a validation check and a rejection if the client doesn't offer H264.