### PR TITLE
fix: rtcp_mux removed in codec overwrite

### DIFF
--- a/teleoprtc/stream.py
+++ b/teleoprtc/stream.py
@@ -274,6 +274,11 @@ class WebRTCAnswerStream(WebRTCBaseStream):
       m.rtp.codecs = preferred_codecs
       m.fmt = [c.payloadType for c in preferred_codecs]
 
+    for m in desc.media:
+      if m.kind in ["audio", "video"] and m.rtcp_mux and m.rtcp_port is None:
+        m.rtcp_port = 9
+        m.rtcp_host = "0.0.0.0"
+
     return str(desc)
 
   async def start(self) -> aiortc.RTCSessionDescription:

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -119,6 +119,42 @@ a=setup:actpass"""
     codecs = video_desc.rtp.codecs
     assert codecs[0].mimeType == "video/H264"
 
+  async def test_firefox_rtcp_mux_without_rtcp_line(self):
+    offer_sdp = """v=0
+o=- 3910274679 3910274679 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic:WMS *
+m=video 9 UDP/TLS/RTP/SAVPF 99
+c=IN IP4 0.0.0.0
+a=recvonly
+a=mid:0
+a=msid:34803878-98f8-4245-b45c-f773e5f926df 881dbc20-356a-499c-b4e8-695303bb901d
+a=rtcp-mux
+a=ssrc-group:FID 1303546896 3784011659
+a=ssrc:1303546896 cname:a59185ac-c115-48d3-b39b-db7d615a6966
+a=ssrc:3784011659 cname:a59185ac-c115-48d3-b39b-db7d615a6966
+a=rtpmap:99 H264/90000
+a=rtcp-fb:99 nack
+a=rtcp-fb:99 nack pli
+a=rtcp-fb:99 goog-remb
+a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
+a=ice-ufrag:1234
+a=ice-pwd:1234
+a=fingerprint:sha-256 15:F3:F0:23:67:44:EE:2C:AA:8C:D9:50:95:26:42:7C:67:EA:1F:D2:92:C5:97:01:7B:2E:57:C9:A3:13:00:4A
+a=setup:actpass
+a=candidate:0 1 UDP 2122252543 host-3e4a2b1c.local 53705 typ host"""
+
+    builder = WebRTCAnswerBuilder(offer_sdp)
+    builder.add_video_stream("road", DummyH264VideoStreamTrack("road", 0.05))
+    stream = builder.stream()
+    _ = await stream.start()
+
+    assert "a=rtcp:9" in stream.session.sdp
+    assert "a=rtcp-mux" in stream.session.sdp
+    assert "host-3e4a2b1c.local" in stream.session.sdp
+
   async def test_fail_if_preferred_codec_not_in_offer(self):
     offer_sdp = """v=0
 o=- 3910274679 3910274679 IN IP4 0.0.0.0

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -151,9 +151,7 @@ a=candidate:0 1 UDP 2122252543 host-3e4a2b1c.local 53705 typ host"""
     stream = builder.stream()
     _ = await stream.start()
 
-    assert "a=rtcp:9" in stream.session.sdp
     assert "a=rtcp-mux" in stream.session.sdp
-    assert "host-3e4a2b1c.local" in stream.session.sdp
 
   async def test_fail_if_preferred_codec_not_in_offer(self):
     offer_sdp = """v=0


### PR DESCRIPTION
teleoprtc stream takes in SDP offer from peer, parses it with aiortc into an object, mutates the object to force a codec, serializes it and then feeds it again into a session description parser. This process makes it lose its a=rtcp-mux field because its rtcp_port value is None. This is because some firefox sdp offers omit the rtcp port field.

a fix to this is to write a dummy port and host to the sdp offer after the codec is overwritten to make sure that the serialization does not remove the rtcp-mux field.

We can use special values DISCARD_PORT=9 and DISCARD_HOST=0.0.0.0 as dummy values since they are apart of the [Discard Protocol](https://en.wikipedia.org/wiki/Discard_Protocol) and are recognized no-op values in tcp/udp. In fact Chrome's SDP offer actually uses these values by default for rtcp-mux:

```
c=IN IP4 67.208.245.10
a=rtcp:9 IN IP4 0.0.0.0
a=candidate:2005618654 1 udp 2122260223 192.168.42.6 60634 typ host generation 0 network-id 1
```

It is unclear to me when firefox omits or keeps the rtcp port field, so this will be in draft for now.

reference:
https://www.rfc-editor.org/rfc/rfc5761.html#section-5.1.3