### PR TITLE
fix: overwite host of mDNS ICE candidates

### DIFF
--- a/teleoprtc/stream.py
+++ b/teleoprtc/stream.py
@@ -274,9 +274,15 @@ class WebRTCAnswerStream(WebRTCBaseStream):
       m.rtp.codecs = preferred_codecs
       m.fmt = [c.payloadType for c in preferred_codecs]
 
-    # overwrite mDNS hostnames which crash sdp serialization
+    # aiortc only serializes a=rtcp-mux if rtcp_port is set. Firefox offers
+    # can omit a=rtcp while still advertising rtcp-mux, so synthesize the
+    # placeholder RTCP address before re-serializing the filtered SDP.
     for m in desc.media:
-      if m.kind in ["audio", "video"] and m.rtcp_mux and m.rtcp_host and m.rtcp_host.endswith(".local"):
+      if m.kind not in ["audio", "video"] or not m.rtcp_mux:
+        continue
+      if m.rtcp_port is None:
+        m.rtcp_port = 9
+      if m.rtcp_host and m.rtcp_host.endswith(".local"):
         m.rtcp_host = "0.0.0.0"
 
     return str(desc)

--- a/teleoprtc/stream.py
+++ b/teleoprtc/stream.py
@@ -274,6 +274,10 @@ class WebRTCAnswerStream(WebRTCBaseStream):
       m.rtp.codecs = preferred_codecs
       m.fmt = [c.payloadType for c in preferred_codecs]
 
+    for m in desc.media:
+      if m.kind in ["audio", "video"] and m.rtcp_mux:
+        m.rtcp_host = "0.0.0.0"
+
     return str(desc)
 
   async def start(self) -> aiortc.RTCSessionDescription:

--- a/teleoprtc/stream.py
+++ b/teleoprtc/stream.py
@@ -274,8 +274,9 @@ class WebRTCAnswerStream(WebRTCBaseStream):
       m.rtp.codecs = preferred_codecs
       m.fmt = [c.payloadType for c in preferred_codecs]
 
+    # overwrite mDNS hostnames which crash sdp serialization
     for m in desc.media:
-      if m.kind in ["audio", "video"] and m.rtcp_mux:
+      if m.kind in ["audio", "video"] and m.rtcp_mux and m.rtcp_host and m.rtcp_host.endswith(".local"):
         m.rtcp_host = "0.0.0.0"
 
     return str(desc)

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -156,6 +156,41 @@ a=setup:actpass"""
     stream = builder.stream()
     _ = await stream.start()
 
+  async def test_sdp_offer_with_mDNS_candidate_and_no_rtcp_attribute(self):
+    offer_sdp = """v=0
+o=mozilla...THIS_IS_SDPARTA-99.0 3533862303229651784 0 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 8B:F4:4E:05:FF:55:5B:A5:A2:F2:D8:EE:DA:67:CA:05:8D:88:7D:41:5D:47:49:0D:79:BF:77:ED:6B:99:52:83
+a=group:BUNDLE 0
+a=ice-options:trickle
+a=msid-semantic:WMS *
+m=video 9 UDP/TLS/RTP/SAVPF 97 99
+c=IN IP4 0.0.0.0
+a=recvonly
+a=mid:0
+a=rtcp-mux
+a=candidate:0 1 UDP 2122252543 16d435ed-eb25-4cf2-aa3d-1dd75004bfc5.local 46047 typ host
+a=rtpmap:97 VP8/90000
+a=rtpmap:99 H264/90000
+a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
+a=ice-ufrag:1234
+a=ice-pwd:1234
+a=fingerprint:sha-256 15:F3:F0:23:67:44:EE:2C:AA:8C:D9:50:95:26:42:7C:67:EA:1F:D2:92:C5:97:01:7B:2E:57:C9:A3:13:00:4A
+a=setup:actpass"""
+
+    builder = WebRTCAnswerBuilder(offer_sdp)
+    builder.add_video_stream("road", DummyH264VideoStreamTrack("road", 0.05))
+    stream = builder.stream()
+
+    rewritten_sdp = stream._override_incoming_video_codecs(stream.session.sdp, ["H264"])
+    sdp_desc = aiortc.sdp.SessionDescription.parse(rewritten_sdp)
+    video_desc = [m for m in sdp_desc.media if m.kind == "video"][0]
+
+    assert "a=rtcp-mux" in rewritten_sdp
+    assert video_desc.rtcp_mux
+    assert video_desc.rtcp_port == 9
+
   async def test_fail_if_preferred_codec_not_in_offer(self):
     offer_sdp = """v=0
 o=- 3910274679 3910274679 IN IP4 0.0.0.0

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -119,6 +119,43 @@ a=setup:actpass"""
     codecs = video_desc.rtp.codecs
     assert codecs[0].mimeType == "video/H264"
 
+  async def test_sdp_offer_with_mDNS_hostname(self):
+    offer_sdp = """v=0
+o=mozilla...THIS_IS_SDPARTA-99.0 3533862303229651784 0 IN IP4 0.0.0.0
+s=-
+t=0 0
+a=fingerprint:sha-256 8B:F4:4E:05:FF:55:5B:A5:A2:F2:D8:EE:DA:67:CA:05:8D:88:7D:41:5D:47:49:0D:79:BF:77:ED:6B:99:52:83
+a=group:BUNDLE 0
+a=ice-options:trickle
+a=msid-semantic:WMS *
+m=video 46047 UDP/TLS/RTP/SAVPF 97
+c=IN IP4 67.208.245.10
+a=recvonly
+a=mid:0
+a=rtcp:36842 IN IP4 16d435ed-eb25-4cf2-aa3d-1dd75004bfc5.local
+a=rtcp-mux
+a=ssrc-group:FID 1303546896 3784011659
+a=ssrc:1303546896 cname:a59185ac-c115-48d3-b39b-db7d615a6966
+a=ssrc:3784011659 cname:a59185ac-c115-48d3-b39b-db7d615a6966
+a=rtpmap:97 VP8/90000
+a=rtcp-fb:97 nack
+a=rtcp-fb:97 nack pli
+a=rtcp-fb:97 goog-remb
+a=rtpmap:99 H264/90000
+a=rtcp-fb:99 nack
+a=rtcp-fb:99 nack pli
+a=rtcp-fb:99 goog-remb
+a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
+a=ice-ufrag:1234
+a=ice-pwd:1234
+a=fingerprint:sha-256 15:F3:F0:23:67:44:EE:2C:AA:8C:D9:50:95:26:42:7C:67:EA:1F:D2:92:C5:97:01:7B:2E:57:C9:A3:13:00:4A
+a=setup:actpass"""
+
+    builder = WebRTCAnswerBuilder(offer_sdp)
+    builder.add_video_stream("road", DummyH264VideoStreamTrack("road", 0.05))
+    stream = builder.stream()
+    _ = await stream.start()
+
   async def test_fail_if_preferred_codec_not_in_offer(self):
     offer_sdp = """v=0
 o=- 3910274679 3910274679 IN IP4 0.0.0.0


### PR DESCRIPTION
firefox obfuscates host IP with mDNS. Aiortc does not resolve to the IP and in override codec function it tries to serialize the offer, but it cannot handle a non IPv4 or IPv6 address.

we can overwrite the rtcp_host to be 0.0.0.0 to fix this serialization issue. This is what is done in a Chrome SDP offer:
```
c=IN IP4 67.208.245.10
a=rtcp:9 IN IP4 0.0.0.0
a=candidate:2005618654 1 udp 2122260223 192.168.42.6 60634 typ host generation 0 network-id 1
```

This bug only appears in Firefox. This can also be fixed by setting rtcp_host to None, which `aiortc>=1.14.0` supports.